### PR TITLE
change insert(ctx) a insertOne(ctx)

### DIFF
--- a/packages/database/src/mongo/index.js
+++ b/packages/database/src/mongo/index.js
@@ -29,7 +29,7 @@ class MongoAdapter {
     }
 
     save = async (ctx) => {
-        await this.db.collection('history').insert(ctx)
+        await this.db.collection('history').insertOne(ctx)
         this.listHistory.push(ctx)
     }
 }


### PR DESCRIPTION
# Que tipo de Pull Request es?

- [x ] Mejora
- [ ] Bug
- [ ] Docs / tests

# Descripción

By good practices given by mongo it is no longer suggested to use insert but insertOne should be used.

This contribution goes since the bot that I use and is connected to mongo Atlas and in the Heroku console where I have mounted the app throws me the following output:

(node:20) [MONGODB DRIVER] Warning: collection.insert is deprecated. Use insertOne, insertMany or bulkWrite instead.

![image](https://user-images.githubusercontent.com/52834256/236525206-314368dc-dce2-43b3-8733-5c4752caea9c.png)

> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [Twitter](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
