### PR TITLE
feat(provider): read whatsapp message template buttons

### DIFF
--- a/packages/provider/src/meta/server.js
+++ b/packages/provider/src/meta/server.js
@@ -46,10 +46,21 @@ class MetaWebHookServer extends EventEmitter {
             }
             this.emit('message', responseObj)
         }
-        
+
+        if (message.type === 'button') {
+            const body = message.button?.text
+            const responseObj = {
+                type: message.type,
+                from: message.from,
+                to,
+                body,
+            }
+            this.emit('message', responseObj)
+        }
+
         if (message.type === 'interactive') {
-            const body = message.interactive?.button_reply?.title || message.interactive?.list_reply?.id;
-            const title_list_reply = message.interactive?.list_reply?.title;
+            const body = message.interactive?.button_reply?.title || message.interactive?.list_reply?.id
+            const title_list_reply = message.interactive?.list_reply?.title
             const responseObj = {
                 type: 'interactive',
                 from: message.from,
@@ -57,7 +68,7 @@ class MetaWebHookServer extends EventEmitter {
                 body,
                 title_list_reply,
             }
-            this.emit('message', responseObj);
+            this.emit('message', responseObj)
         }
 
         if (message.type === 'image') {


### PR DESCRIPTION
# Que tipo de Pull Request es?

- [ X ] Mejoras
- [ ] Bug
- [ ] Docs / tests

# Descripción

Leer una respuesta a partir de un botón generado por un template de mensajes de Meta.

Actualmente me encuentro trabajando con el provider de Meta en el bot. En mi caso, es necesario establecer una conversación iniciada por mi empresa con un cliente en específico, por lo que creamos un template que es aprobado por Meta y se lo envíamos a nuestros clientes finales para que a partir de ese mensaje inicien una conversación con el bot.


Este es un ejemplo del mensaje que es enviado a través del API de Meta.
![image](https://github.com/codigoencasa/bot-whatsapp/assets/45320484/4faffdb8-a900-4ec7-8915-52eaef74131f)

El problema surge al momento en que se reacciona a uno de los botones proporcionados por la plantilla dado que la librería no tiene contemplado un mensaje de tipo "button", por lo que es como si el mensaje nunca llegara. Para poder continuar con el flujo tocaba escribir manualmente el mensaje.
![image](https://github.com/codigoencasa/bot-whatsapp/assets/45320484/274aef04-8131-4dab-9419-d460869df99b)

La solución fue agregar una validación para cuando el mensaje es de tipo "button" que va a formatear el body del mensaje de forma correcta para que se continuen los flujos creados.
![image](https://github.com/codigoencasa/bot-whatsapp/assets/45320484/464abf75-d003-411f-92ff-da35bfd19d60)

Error corregido
![image](https://github.com/codigoencasa/bot-whatsapp/assets/45320484/ed5f6ede-3f0f-4126-b119-7017e470d75a)


