### PR TITLE
sticker,image,video to _event_media

### DIFF
--- a/packages/provider/src/meta/server.js
+++ b/packages/provider/src/meta/server.js
@@ -61,7 +61,7 @@ class MetaWebHookServer extends EventEmitter {
         }
 
         if (message.type === 'image') {
-            const body = generateRefprovider('_event_image_')
+            const body = generateRefprovider('_event_media_')
             const idUrl = message.image?.id
             const resolvedUrl = await getMediaUrl(this.version, idUrl, this.numberId, this.jwtToken)
             const responseObj = {
@@ -91,7 +91,7 @@ class MetaWebHookServer extends EventEmitter {
         }
 
         if (message.type === 'video') {
-            const body = generateRefprovider('_event_video_')
+            const body = generateRefprovider('_event_media_')
             const idUrl = message.video?.id
 
             const resolvedUrl = await getMediaUrl(this.version, idUrl, this.numberId, this.jwtToken)
@@ -138,7 +138,7 @@ class MetaWebHookServer extends EventEmitter {
         }
 
         if (message.type === 'sticker') {
-            const body = generateRefprovider('_event_sticker_')
+            const body = generateRefprovider('_event_media_')
 
             const responseObj = {
                 type: message.type,


### PR DESCRIPTION
# Que tipo de Pull Request es?

- [X] Mejoras
- [X] Bug
- [ ] Docs / tests

# Descripción

Los eventos de Imágenes, Vídeo y Sticker del proveedor Meta, tenían un hash distinto que no coincidia con EVENTS.MEDIA, por lo tanto ninguno se activaba al usar ese evento.

Flujo que se usó para pruebas : 

```js
const mediaFlow = addKeyword(EVENTS.MEDIA).addAction(async (ctx, ctxFn) => {
    console.log('Media -->', ctx)
    return ctxFn.endFlow('Gracias por tu archivo')
})
```

Antes del cambio : 

`Como no hay coincidencia con EVENTS.MEDIA el evento no entra al flujo y no se recibe respuesta`

![img-noresponse](https://github.com/codigoencasa/bot-whatsapp/assets/116053539/d69d0e98-7d74-41d9-9e8e-c72ab188c6bb)


Después del cambio : 

`Al usar el prefijo correcto ahora son eventos que coinciden con EVENTS.MEDIA y se recibe la respuesta esperada`

![img-response](https://github.com/codigoencasa/bot-whatsapp/assets/116053539/236295f9-2b80-4a1b-a439-126843393e3a)

Payload : 

![imagePayload](https://github.com/codigoencasa/bot-whatsapp/assets/116053539/a341d2ae-8913-427f-b1ec-185d393f78aa)


> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [Twitter](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
