### PR TITLE
Seguridad de private keys para deployment DialogFlow

### DIFF
--- a/packages/contexts/src/dialogflow-cx/dialogflow-cx.class.js
+++ b/packages/contexts/src/dialogflow-cx/dialogflow-cx.class.js
@@ -7,8 +7,12 @@ const { join } = require('path')
  * Necesita extender de core.class
  * handleMsg(messageInComming) //   const { body, from } = messageInComming
  */
+//Darle al usuario la opcion de no publicar sus claves de Google y pasarlas como variable de entorno
+let GOOGLE_ACCOUNT_PATH = join(process.cwd(), 'google-key.json');
 
-const GOOGLE_ACCOUNT_PATH = join(process.cwd(), 'google-key.json')
+if (!fs.existsSync(googleKeyFilePath)) {
+    GOOGLE_ACCOUNT_PATH = JSON.parse(process.env.GOOGLE_KEY_JSON);
+}
 
 class DialogFlowCXContext extends CoreClass {
     // Opciones del usuario

--- a/packages/contexts/src/dialogflow-cx/dialogflow-cx.class.js
+++ b/packages/contexts/src/dialogflow-cx/dialogflow-cx.class.js
@@ -3,17 +3,6 @@ const { SessionsClient } = require('@google-cloud/dialogflow-cx').v3beta1
 const { existsSync, readFileSync } = require('fs')
 const { join } = require('path')
 
-/**
- * Necesita extender de core.class
- * handleMsg(messageInComming) //   const { body, from } = messageInComming
- */
-//Darle al usuario la opcion de no publicar sus claves de Google y pasarlas como variable de entorno
-let GOOGLE_ACCOUNT_PATH = join(process.cwd(), 'google-key.json');
-
-if (!fs.existsSync(googleKeyFilePath)) {
-    GOOGLE_ACCOUNT_PATH = JSON.parse(process.env.GOOGLE_KEY_JSON);
-}
-
 class DialogFlowCXContext extends CoreClass {
     // Opciones del usuario
     optionsDX = {
@@ -22,7 +11,6 @@ class DialogFlowCXContext extends CoreClass {
         agentId: '',
     }
     projectId = null
-    configuration = null
     sessionClient = null
 
     constructor(_database, _provider, _optionsDX = {}) {
@@ -35,26 +23,32 @@ class DialogFlowCXContext extends CoreClass {
      * Verificar conexión con servicio de DialogFlow
      */
     init = () => {
-        if (!existsSync(GOOGLE_ACCOUNT_PATH)) {
-            console.log(`[ERROR]: No se encontro ${GOOGLE_ACCOUNT_PATH}`)
-            /**
-             * Emitir evento de error para que se mueste por consola dicinedo que no tiene el json
-             *  */
+        let credentials;
+        const googleKeyFilePath = join(process.cwd(), 'google-key.json');
+
+        if (existsSync(googleKeyFilePath)) {
+            const rawJson = readFileSync(googleKeyFilePath, 'utf-8');
+            credentials = JSON.parse(rawJson);
+        } else if (process.env.GOOGLE_KEY_JSON) {
+            credentials = JSON.parse(process.env.GOOGLE_KEY_JSON);
+        } else {
+            throw new Error('Google key configuration not found');
         }
 
-        if (!this.optionsDX.location.length) throw new Error('LOCATION_NO_ENCONTRADO')
-        if (!this.optionsDX.agentId.length) throw new Error('AGENTID_NO_ENCONTRADO')
+        if (!this.optionsDX.location.length) throw new Error('LOCATION_NO_ENCONTRADO');
+        if (!this.optionsDX.agentId.length) throw new Error('AGENTID_NO_ENCONTRADO');
 
-        const rawJson = readFileSync(GOOGLE_ACCOUNT_PATH, 'utf-8')
-        const { project_id, private_key, client_email } = JSON.parse(rawJson)
+        const { project_id, private_key, client_email } = credentials;
 
-        this.projectId = project_id
+        this.projectId = project_id;
 
         this.sessionClient = new SessionsClient({
             credentials: { private_key, client_email },
             apiEndpoint: `${this.optionsDX.location}-dialogflow.googleapis.com`,
-        })
+        });
     }
+
+
 
     /**
      * GLOSSARY.md


### PR DESCRIPTION
Permite al usuario crear una variable de entorno GOOGLE_KEY_JSON con sus keys de Google para usar DialogFlowCX sin tener que pushear el archivo google-key.json

# Que tipo de Pull Request es?

- [x] Mejoras
- [ ] Bug
- [ ] Docs / tests

# Descripción

Cambio en el archivo de DialogFlowCx dentro de contexts chequeando si existe el archivo pusheado de google keys y si no esta en el directorio utiliza la variable de entorno
