### PR TITLE
feat: se adiciona ctx msg_id (id mensaje entrante)

### DIFF
--- a/packages/database/src/mysql/index.js
+++ b/packages/database/src/mysql/index.js
@@ -49,9 +49,9 @@ class MyslAdapter {
 
     save = (ctx) => {
         const values = [
-            [ctx.ref, ctx.keyword, ctx.answer, ctx.refSerialize, ctx.from, JSON.stringify(ctx.options)],
+            [ctx.ref, ctx.keyword, ctx.answer, ctx.refSerialize, ctx.from, JSON.stringify(ctx.options), null],
         ]
-        const sql = 'INSERT INTO history (ref, keyword, answer, refSerialize, phone, options) values ?'
+        const sql = 'INSERT INTO history (ref, keyword, answer, refSerialize, phone, options, created_at) values ?'
 
         this.db.query(sql, [values], (err) => {
             if (err) throw err
@@ -68,7 +68,7 @@ class MyslAdapter {
             ref varchar(255) NOT NULL,
             keyword varchar(255) NULL,
             answer longtext NOT NULL,
-            refSerialize varchar(255) NULL,
+            refSerialize varchar(255) NOT NULL,
             phone varchar(255) NOT NULL,
             options longtext NOT NULL,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP) 

--- a/packages/database/src/mysql/index.js
+++ b/packages/database/src/mysql/index.js
@@ -49,9 +49,9 @@ class MyslAdapter {
 
     save = (ctx) => {
         const values = [
-            [ctx.ref, ctx.keyword, ctx.answer, ctx.refSerialize, ctx.from, JSON.stringify(ctx.options), null],
+            [ctx.ref, ctx.keyword, ctx.answer, ctx.refSerialize, ctx.from, JSON.stringify(ctx.options)],
         ]
-        const sql = 'INSERT INTO history (ref, keyword, answer, refSerialize, phone, options, created_at) values ?'
+        const sql = 'INSERT INTO history (ref, keyword, answer, refSerialize, phone, options) values ?'
 
         this.db.query(sql, [values], (err) => {
             if (err) throw err
@@ -68,7 +68,7 @@ class MyslAdapter {
             ref varchar(255) NOT NULL,
             keyword varchar(255) NULL,
             answer longtext NOT NULL,
-            refSerialize varchar(255) NOT NULL,
+            refSerialize varchar(255) NULL,
             phone varchar(255) NOT NULL,
             options longtext NOT NULL,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP) 

--- a/packages/provider/src/meta/server.js
+++ b/packages/provider/src/meta/server.js
@@ -40,6 +40,8 @@ class MetaWebHookServer extends EventEmitter {
             return
         }
 
+        const msg_id = messages[0].id
+
         messages.forEach(async (message) => {
             const [contact] = contacts
             const to = body.entry[0].changes[0].value?.metadata?.display_phone_number
@@ -54,6 +56,7 @@ class MetaWebHookServer extends EventEmitter {
                         to,
                         body: message.text?.body,
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -66,6 +69,7 @@ class MetaWebHookServer extends EventEmitter {
                         title_button_reply: message.interactive?.button_reply?.title,
                         title_list_reply: message.interactive?.list_reply?.title,
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -78,6 +82,7 @@ class MetaWebHookServer extends EventEmitter {
                         payload: message.button?.payload,
                         title_button_reply: message.button?.payload,
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -90,6 +95,7 @@ class MetaWebHookServer extends EventEmitter {
                         to,
                         body: generateRefprovider('_event_media_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -107,6 +113,7 @@ class MetaWebHookServer extends EventEmitter {
                         to,
                         body: generateRefprovider('_event_document_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -119,6 +126,7 @@ class MetaWebHookServer extends EventEmitter {
                         to,
                         body: generateRefprovider('_event_media_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -131,6 +139,7 @@ class MetaWebHookServer extends EventEmitter {
                         longitude: message.location.longitude,
                         body: generateRefprovider('_event_location_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -143,6 +152,7 @@ class MetaWebHookServer extends EventEmitter {
                         to,
                         body: generateRefprovider('_event_audio_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -154,6 +164,7 @@ class MetaWebHookServer extends EventEmitter {
                         id: message.sticker.id,
                         body: generateRefprovider('_event_media_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -170,6 +181,7 @@ class MetaWebHookServer extends EventEmitter {
                         to,
                         body: generateRefprovider('_event_contacts_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -184,6 +196,7 @@ class MetaWebHookServer extends EventEmitter {
                         },
                         body: generateRefprovider('_event_order_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }


### PR DESCRIPTION
msg_id se puede utilizar para hacer referencia a un mensaje, ejemplo una reaccion

# Que tipo de Pull Request es?

- [ X] Mejoras
- [ ] Bug
- [ ] Docs / tests

Se adiciona msg_id (id de un mensaje entrante), el cual es necesario para hacer referencia a un mensaje enviado por el usuario, por ejemplo si se requiere hacer una reaccion a un mensaje el msg_id es obligatorio.

![Screenshot 2023-11-20 at 10 02 48 AM](https://github.com/codigoencasa/bot-whatsapp/assets/52203336/c948f727-a002-4a2f-ac81-34578f8c71e9)

<img width="1249" alt="Screenshot 2023-11-20 at 10 03 21 AM" src="https://github.com/codigoencasa/bot-whatsapp/assets/52203336/d7da23e4-1d32-41fd-813b-4c0443b4bd17">

Codigo ejemplo:

![Screenshot 2023-11-20 at 10 04 15 AM](https://github.com/codigoencasa/bot-whatsapp/assets/52203336/6d3486aa-3bc8-49d2-af85-007121f2b940)

> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [𝕏 (Twitter)](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
