### PR TITLE
Fix/issue 920 - refSerialize acepta null

### DIFF
--- a/packages/database/src/mysql/index.js
+++ b/packages/database/src/mysql/index.js
@@ -49,9 +49,9 @@ class MyslAdapter {
 
     save = (ctx) => {
         const values = [
-            [ctx.ref, ctx.keyword, ctx.answer, ctx.refSerialize, ctx.from, JSON.stringify(ctx.options)],
+            [ctx.ref, ctx.keyword, ctx.answer, ctx.refSerialize, ctx.from, JSON.stringify(ctx.options), null],
         ]
-        const sql = 'INSERT INTO history (ref, keyword, answer, refSerialize, phone, options) values ?'
+        const sql = 'INSERT INTO history (ref, keyword, answer, refSerialize, phone, options, created_at) values ?'
 
         this.db.query(sql, [values], (err) => {
             if (err) throw err
@@ -68,7 +68,7 @@ class MyslAdapter {
             ref varchar(255) NOT NULL,
             keyword varchar(255) NULL,
             answer longtext NOT NULL,
-            refSerialize varchar(255) NULL,
+            refSerialize varchar(255) NOT NULL,
             phone varchar(255) NOT NULL,
             options longtext NOT NULL,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP) 

--- a/packages/database/src/mysql/index.js
+++ b/packages/database/src/mysql/index.js
@@ -49,9 +49,9 @@ class MyslAdapter {
 
     save = (ctx) => {
         const values = [
-            [ctx.ref, ctx.keyword, ctx.answer, ctx.refSerialize, ctx.from, JSON.stringify(ctx.options), null],
+            [ctx.ref, ctx.keyword, ctx.answer, ctx.refSerialize, ctx.from, JSON.stringify(ctx.options)],
         ]
-        const sql = 'INSERT INTO history (ref, keyword, answer, refSerialize, phone, options, created_at) values ?'
+        const sql = 'INSERT INTO history (ref, keyword, answer, refSerialize, phone, options) values ?'
 
         this.db.query(sql, [values], (err) => {
             if (err) throw err
@@ -68,7 +68,7 @@ class MyslAdapter {
             ref varchar(255) NOT NULL,
             keyword varchar(255) NULL,
             answer longtext NOT NULL,
-            refSerialize varchar(255) NOT NULL,
+            refSerialize varchar(255) NULL,
             phone varchar(255) NOT NULL,
             options longtext NOT NULL,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP) 

--- a/packages/provider/src/meta/server.js
+++ b/packages/provider/src/meta/server.js
@@ -40,6 +40,8 @@ class MetaWebHookServer extends EventEmitter {
             return
         }
 
+        const msg_id = messages[0].id
+
         messages.forEach(async (message) => {
             const [contact] = contacts
             const to = body.entry[0].changes[0].value?.metadata?.display_phone_number
@@ -54,6 +56,7 @@ class MetaWebHookServer extends EventEmitter {
                         to,
                         body: message.text?.body,
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -66,6 +69,7 @@ class MetaWebHookServer extends EventEmitter {
                         title_button_reply: message.interactive?.button_reply?.title,
                         title_list_reply: message.interactive?.list_reply?.title,
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -78,6 +82,7 @@ class MetaWebHookServer extends EventEmitter {
                         payload: message.button?.payload,
                         title_button_reply: message.button?.payload,
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -90,6 +95,7 @@ class MetaWebHookServer extends EventEmitter {
                         to,
                         body: generateRefprovider('_event_media_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -107,6 +113,7 @@ class MetaWebHookServer extends EventEmitter {
                         to,
                         body: generateRefprovider('_event_document_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -119,6 +126,7 @@ class MetaWebHookServer extends EventEmitter {
                         to,
                         body: generateRefprovider('_event_media_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -131,6 +139,7 @@ class MetaWebHookServer extends EventEmitter {
                         longitude: message.location.longitude,
                         body: generateRefprovider('_event_location_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -143,6 +152,7 @@ class MetaWebHookServer extends EventEmitter {
                         to,
                         body: generateRefprovider('_event_audio_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -154,6 +164,7 @@ class MetaWebHookServer extends EventEmitter {
                         id: message.sticker.id,
                         body: generateRefprovider('_event_media_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -170,6 +181,7 @@ class MetaWebHookServer extends EventEmitter {
                         to,
                         body: generateRefprovider('_event_contacts_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }
@@ -184,6 +196,7 @@ class MetaWebHookServer extends EventEmitter {
                         },
                         body: generateRefprovider('_event_order_'),
                         pushName,
+                        msg_id
                     }
                     break
                 }


### PR DESCRIPTION
# Que tipo de Pull Request es?

- [ ] Mejoras
- [ X] Bug
- [ ] Docs / tests

se modifica la creacion de la tabla history para aceptar valores null en el campo refSerialize, adicionalemnte se remueve el valor de null y created_at de la instruccion INSERTO INTO histoy para grabar la fecha actual en cada registro (anteriormente estaba en null).

<img width="1011" alt="Screenshot 2023-11-20 at 10 48 38 AM" src="https://github.com/codigoencasa/bot-whatsapp/assets/52203336/8722fbda-4dfb-434b-8650-f0538f440257">

![Screenshot 2023-11-20 at 10 50 01 AM](https://github.com/codigoencasa/bot-whatsapp/assets/52203336/1780c182-ea94-4127-a291-43d450dbfd58)



> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [𝕏 (Twitter)](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
