### PR TITLE
fix(database): mysql is setting null value in created_at column

### DIFF
--- a/packages/database-mysql/src/mysqlAdapter.ts
+++ b/packages/database-mysql/src/mysqlAdapter.ts
@@ -57,9 +57,9 @@ class MysqlAdapter extends MemoryDB {
         options: any
     }): Promise<void> => {
         const values = [
-            [ctx.ref, ctx.keyword, ctx.answer, ctx.refSerialize, ctx.from, JSON.stringify(ctx.options), null],
+            [ctx.ref, ctx.keyword, ctx.answer, ctx.refSerialize, ctx.from, JSON.stringify(ctx.options)],
         ]
-        const sql = 'INSERT INTO history (ref, keyword, answer, refSerialize, phone, options, created_at) values ?'
+        const sql = 'INSERT INTO history (ref, keyword, answer, refSerialize, phone, options) values ?'
 
         this.db.query<OkPacket>(sql, [values], (err: any) => {
             if (err) throw err


### PR DESCRIPTION
# Que tipo de Pull Request es?

- [ ] Mejoras
- [x] Bug
- [ ] Docs / tests

# Descripción

Fix super cortito: al usar MySQL y guardar en la tabla de `history` se esta estableciendo un valor `null`en la columna de `created_at`. Esta columna ya tiene un valor por defecto, colocando la fecha actual al crear el registro, pero al pasarle explicitamente el valor `null` toma ese en su lugar.

Para solucionarlo solo es necesario quitar de los parametros a guardar el valor `null`y dejar que el motor de MySQL inserte el valor de la fecha actual en la columna.
