### PR TITLE
fix(provider): :bug: manejo de TextMessagBody.to al usar sendMessageT…

### DIFF
--- a/packages/provider-meta/src/meta/provider.ts
+++ b/packages/provider-meta/src/meta/provider.ts
@@ -641,8 +641,22 @@ class MetaProvider extends ProviderClass<MetaInterface> implements MetaInterface
         return this.queue.add(() => this.sendMessageToApi(body))
     }
 
+    prefixMap = {
+        '549': '54', // ARG prefix
+        '521': '52', // MEX prefix
+    }
+
+    fixPrefixMetaNumber = (phoneNumber) => {
+        for (const [prev, current] of Object.entries(this.prefixMap)) {
+            if (phoneNumber.startsWith(prev)) {
+                return phoneNumber.replace(prev, current)
+            }
+        }
+        return phoneNumber
+    }
+
     sendMessageToApi = async (body: TextMessageBody): Promise<any> => {
-        body.to = body.to.startsWith('549') ? '54' + body.to.substring(3) : body.to
+        body.to = this.fixPrefixMetaNumber(body.to)
 
         try {
             const fullUrl = `${URL}/${this.globalVendorArgs.version}/${this.globalVendorArgs.numberId}/messages`

--- a/packages/provider-meta/src/meta/provider.ts
+++ b/packages/provider-meta/src/meta/provider.ts
@@ -642,6 +642,8 @@ class MetaProvider extends ProviderClass<MetaInterface> implements MetaInterface
     }
 
     sendMessageToApi = async (body: TextMessageBody): Promise<any> => {
+        body.to = body.to.startsWith('549') ? '54' + body.to.substring(3) : body.to
+
         try {
             const fullUrl = `${URL}/${this.globalVendorArgs.version}/${this.globalVendorArgs.numberId}/messages`
             const response = await axios.post(fullUrl, body, {


### PR DESCRIPTION
…oApi para números de teléfono de Argentina con META (en modo de prueba)


# Que tipo de Pull Request es?

- [ ] Mejoras
- [ X ] Bug
- [ ] Docs / tests

# Descripción

Este error se origina al usar el modo de prueba de META, luego de haber configurado lo necesario y tenerlo conectado. Al recibir cualquier mensaje, la librería intenta mandarle a meta el mensaje, y retorna error. (la causa es que no coincide el numero que le habla, con los números habilitados para hablar que se configuran en Meta)

Al usar META, y agregar números de prueba, facebook no considera el código de area +549, sino que solo +54. 
Pero, al usar el método para enviar mensajes a la api desde la librería, el numero llega con el 9. Así, es que nunca coinciden los números autorizados de test de META. 

El cambio hace que ahora verifica si el numero comienza con el prefijo de ARG (549), y le saca el 9 para solucionar el problema.

Soluciona al error:

![image](https://github.com/codigoencasa/bot-whatsapp/assets/32769860/a4c23eb4-6848-4e17-bc3d-f4ddb13bd201)



> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [𝕏 (Twitter)](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
