### PR TITLE
fix(provider): 🐛 Agregar displayName a la tarjeta de contacto - Baileys

### DIFF
--- a/packages/provider-baileys/src/bailey.ts
+++ b/packages/provider-baileys/src/bailey.ts
@@ -541,7 +541,7 @@ class BaileysProvider extends ProviderClass<WASocket> {
             'BEGIN:VCARD\n' +
             'VERSION:3.0\n' +
             `FN:${displayName}\n` +
-            'ORG:Ashoka Uni;\n' +
+            `ORG:${displayName}\n` +
             `TEL;type=CELL;type=VOICE;waid=${waid}:${cleanContactNumber}\n` +
             'END:VCARD'
 


### PR DESCRIPTION
# Que tipo de Pull Request es?

- [ ] Mejoras
- [ X ] Bug
- [ ] Docs / tests

# Descripción

Al enviar tarjetas de contacto con Baileys, en lugar del texto predeterminado, mostrar el nombre de contacto seleccionado como displayName.


> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [𝕏 (Twitter)](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
