### PR TITLE
feat: Preview URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@builderbot/root",
   "version": "0.1.35",
-  "description": "Bot de wahtsapp open source para MVP o pequeños negocios",
+  "description": "Bot de whatsapp open source para MVP o pequeños negocios",
   "main": "app.js",
   "private": true,
   "scripts": {

--- a/packages/bot/src/io/methods/addAnswer.ts
+++ b/packages/bot/src/io/methods/addAnswer.ts
@@ -34,6 +34,7 @@ const _addAnswer =
             buttons: Array.isArray(options?.buttons) ? options.buttons : [],
             capture: typeof options?.capture === 'boolean' ? options.capture : false,
             delay: typeof options?.delay === 'number' ? options.delay : 0,
+            preview_url: typeof options?.preview_url ==='boolean' ? options.preview_url : false,
             idle: typeof options?.idle === 'number' ? options.idle : undefined,
             ref: typeof options?.ref === 'string' ? options.ref : undefined,
         })

--- a/packages/bot/src/types.ts
+++ b/packages/bot/src/types.ts
@@ -50,6 +50,7 @@ export type Button = {
  * @property {number} [delay] - Tiempo de retraso para la acción.
  * @property {boolean} [regex] - Indica si se debe usar una expresión regular.
  * @property {boolean} [sensitive] - Indica si la acción es sensible.
+ * @property {boolean} [preview_url] - Indica si debe embeber un thumbnail del link que se envía.
  */
 export type ActionPropertiesKeyword = {
     /** @deprecated Intern use. */
@@ -62,6 +63,7 @@ export type ActionPropertiesKeyword = {
     delay?: number
     regex?: boolean
     sensitive?: boolean
+    preview_url?: boolean
 }
 
 /**
@@ -254,6 +256,7 @@ export interface TFlow<P = any, B = any> {
 export interface SendOptions {
     buttons?: Button[]
     media?: string
+    preview_url?: boolean
     [key: string]: any
 }
 

--- a/packages/provider-meta/src/meta/provider.ts
+++ b/packages/provider-meta/src/meta/provider.ts
@@ -518,7 +518,7 @@ class MetaProvider extends ProviderClass<MetaInterface> implements MetaInterface
         options = { ...options, ...options['options'] }
         if (options?.buttons?.length) return this.sendButtons(to, options.buttons, message)
         if (options?.media) return this.sendMedia(to, message, options.media)
-        this.sendText(to, message)
+        this.sendText(to, message, options)
     }
 
     sendFile = async (to: string, mediaInput = null, caption: string) => {
@@ -655,7 +655,7 @@ class MetaProvider extends ProviderClass<MetaInterface> implements MetaInterface
         return this.sendMessageMeta(body)
     }
 
-    sendText = async (to: string, message: string) => {
+    sendText = async (to: string, message: string, options?: SendOptions) => {
         to = parseMetaNumber(to)
         const body: TextMessageBody = {
             messaging_product: 'whatsapp',
@@ -663,7 +663,7 @@ class MetaProvider extends ProviderClass<MetaInterface> implements MetaInterface
             to,
             type: 'text',
             text: {
-                preview_url: false,
+                preview_url: options.preview_url,
                 body: message,
             },
         }


### PR DESCRIPTION
# Que tipo de Pull Request es?

- [x] Mejoras
- [ ] Bug
- [ ] Docs / tests

# Descripción

Agrega un argumento de tipo `boolean` al objeto de opciones de `addAnswer`: `preview_url`.

<img width="856" alt="image" src="https://github.com/codigoencasa/bot-whatsapp/assets/1136259/0af40612-61e9-42f7-9f56-582d40f27c98">

Con esta opción podemos especificar si queremos que al enviar una URL en nuestra respuesta, el bot ponga el contenido embebido en el mensaje. Si se pone en `true` el bot embebe un preview/thumbnail de la URL, `false` queda como estaba antes (es el default), y no embebe contenido de links.

Por ejemplo, sí envía un link de YouTube, podría verse sin salir de WhatsApp:

![image](https://github.com/codigoencasa/bot-whatsapp/assets/1136259/64616017-0089-4d27-8e24-c1a1425c63ee)

Aguardo comentarios :D
Saludos!

> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [𝕏 (Twitter)](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
