### PR TITLE
Fixing an uncaptured event when sending a document through WhatsApp Web

### DIFF
--- a/packages/provider-baileys/src/bailey.ts
+++ b/packages/provider-baileys/src/bailey.ts
@@ -297,7 +297,7 @@ class BaileysProvider extends ProviderClass<WASocket> {
                 }
 
                 //Detectar file
-                if (messageCtx.message?.documentMessage) {
+                if (messageCtx.message?.documentMessage || messageCtx.message?.documentWithCaptionMessage) {
                     payload = { ...payload, body: utils.generateRefProvider('_event_document_') }
                 }
 


### PR DESCRIPTION
Fixing an uncaptured event when sending a document through WhatsApp Web, "documentWithCaptionMessage"

# Que tipo de Pull Request es?

- [x] Mejoras
- [ ] Bug
- [ ] Docs / tests

# Descripción

- Fixing an uncaptured event when sending a document through WhatsApp Web. From WhatsApp Web, the file name is sent as a message attached to the document.